### PR TITLE
Add compatibility with earlier versions

### DIFF
--- a/src/erldns_zone_cache.erl
+++ b/src/erldns_zone_cache.erl
@@ -178,7 +178,10 @@ zone_names_and_versions() ->
 %% used to determine if the zone requires updating.
 %%
 %% This function will build the necessary Zone record before interting.
--spec put_zone({binary(), binary(), [dns:rr()], [erldns:keyset()]}) -> ok | {error, Reason :: term()}.
+-spec put_zone({Name, Sha, Records, Keys} | {Name, Sha, Records}) -> ok | {error, Reason :: term()}
+  when Name :: binary(), Sha :: binary(), Records :: [dns:rr()], Keys :: [erldns:keyset()].
+put_zone({Name, Sha, Records}) ->
+    put_zone({Name, Sha, Records, []});
 put_zone({Name, Sha, Records, Keys}) ->
   put_zone(erldns:normalize_name(Name), build_zone(Name, Sha, Records, Keys)).
 


### PR DESCRIPTION
https://github.com/aetrion/erl-dns/pull/67

Interface of `put_zone/1` function was changed in [this](https://github.com/aetrion/erl-dns/commit/81ba350ae7ad3dad67c780872d0c2028a3c4159e#diff-8a8e060b9a8de98f1aa024db2afad89bL183) commit.