### PR TITLE
Define default servers in get_servers/0 function

### DIFF
--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -88,7 +88,13 @@ get_servers() ->
              {processes, keyget(processes, Server, 1)}
             ]
         end, Servers);
-    _ -> []
+    undefined ->
+        lists:map(fun (Family) ->
+            [{name, Family},
+             {address, erldns_config:get_address(Family)},
+             {port, erldns_config:get_port()},
+             {family, Family}]
+        end, [inet, inet6])
   end.
 
 -ifdef(TEST).

--- a/src/erldns_server_sup.erl
+++ b/src/erldns_server_sup.erl
@@ -36,14 +36,6 @@ start_link() ->
 init(_Args) ->
   {ok, {{one_for_one, 20, 10}, define_servers(erldns_config:get_servers())}}.
 
-define_servers([]) ->
-  [
-   {udp_inet, {erldns_udp_server, start_link, [udp_inet, inet]}, permanent, 5000, worker, [erldns_udp_server]},
-   {udp_inet6, {erldns_udp_server, start_link, [udp_inet6, inet6]}, permanent, 5000, worker, [erldns_udp_server]},
-   {tcp_inet, {erldns_tcp_server, start_link, [tcp_inet, inet]}, permanent, 5000, worker, [erldns_tcp_server]},
-   {tcp_inet6, {erldns_tcp_server, start_link, [tcp_inet6, inet6]}, permanent, 5000, worker, [erldns_tcp_server]}
-  ];
-
 define_servers(Servers) ->
   lists:flatten(
     lists:map(


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-1946

It allows us to disable erldns tcp and udp servers.

```
{erldns, [
    {servers, []}
]}.
```

Please see https://github.com/dcos/dcos-net/pull/22/files#diff-a20e447d0b40a861040c0b922625585cR33