### PR TITLE
Remove list of records from #zone{}

### DIFF
--- a/include/erldns.hrl
+++ b/include/erldns.hrl
@@ -12,14 +12,15 @@
   }).
 
 -record(zone, {
+    %% records and records_by_type are no longer in use, but cannot (easily) be
+    %% deleted due to Mnesia schema evolution. We cannot set them to undefined,
+    %% because, again, when fetched from Mnesia, they may be set
     name :: dns:dname(),
     version :: binary(),
     authority = [] :: [dns:rr()],
     record_count = 0 :: non_neg_integer(),
-    records = [] :: [dns:rr()],
+    records :: term(),
     records_by_name ::  #{binary() => [dns:rr()]} | trimmed,
-    %% records_by_type is no longer in use, but cannot (easily) be deleted due to Mnesia schema evolution
-    %% We cannot set it to undefined, because, again, when fetched from Mnesia, it may be set
     records_by_type :: term(),
     keysets :: [erldns:keyset()]
   }).

--- a/src/erldns_config.erl
+++ b/src/erldns_config.erl
@@ -99,7 +99,10 @@ get_servers() ->
 
 -ifdef(TEST).
 get_servers_undefined_test() ->
-  ?assertEqual([], get_servers()).
+  ?assertEqual([
+                [{name,inet}, {address,{127,0,0,1}}, {port,53}, {family,inet}],
+                [{name,inet6}, {address,{0,0,0,0,0,0,0,1}}, {port,53}, {family,inet6}]
+               ], get_servers()).
 
 get_servers_empty_list_test() ->
   application:set_env(erldns, servers, []),

--- a/src/erldns_zone_encoder.erl
+++ b/src/erldns_zone_encoder.erl
@@ -115,12 +115,7 @@ record_filter() ->
   end.
 
 records_to_json(Zone, Encoders) ->
-  lists:map(encode(Encoders), Zone#zone.records).
-
-encode(Encoders) ->
-  fun(Record) ->
-      encode_record(Record, Encoders)
-  end.
+  [encode_record(R, Encoders) || RR <- maps:values(Zone#zone.records_by_name), R <- RR].
 
 encode_record(Record, Encoders) ->
   lager:debug("Encoding record (record: ~p)", [Record]),


### PR DESCRIPTION
ErlDNS stores records in `#zone{}` twice, as a list and as a map.
This patch removes the list of records from `#zone{}` and implement
all the features using `#zone.records_by_name`.